### PR TITLE
Adjust priority of icon sources in _getGIconForSource, so app icon comes first

### DIFF
--- a/notification-icons@muhammad_ans.github/extension.js
+++ b/notification-icons@muhammad_ans.github/extension.js
@@ -256,16 +256,16 @@ const TopbarNotification = GObject.registerClass(
         }
 
         _getGIconForSource(source) {
+            if (source.icon && source.icon instanceof Gio.Icon) {
+                return source.icon;
+            }
+
             if (source.notifications && source.notifications.length > 0) {
                 for (const notification of source.notifications) {
                     if (notification.gicon) {
                         return notification.gicon;
                     }
                 }
-            }
-
-            if (source.icon && source.icon instanceof Gio.Icon) {
-                return source.icon;
             }
 
             if (source.app && source.app.get_icon) {


### PR DESCRIPTION
I found that for some apps that display other content as the big icon in the notification, after locking and unlocking the system, it chooses that icon (e.g. social networking sites). The issue exists with which icon `_getGIconForSource` prioritises, so this PR simply moves the main icon choice to the top.

Before:
<img width="464" height="158" alt="image" src="https://github.com/user-attachments/assets/0dd351cf-7d0a-4b5d-89f0-c10171a38549" />


After:
<img width="502" height="161" alt="image" src="https://github.com/user-attachments/assets/9d1da7fc-8923-4684-bc4e-122ddec7487d" />
